### PR TITLE
feat: implement token refresh in MSOB2CAuth class

### DIFF
--- a/pyanglianwater/api.py
+++ b/pyanglianwater/api.py
@@ -30,3 +30,11 @@ class API:
     async def send_request(self, endpoint: str, body: dict):
         """Send a request to the API using the authentication handler."""
         return await self._auth.send_request(endpoint=endpoint, body=body)
+
+    async def token_refresh(self):
+        """Force token refresh."""
+        return await self._auth.send_refresh_request()
+
+    async def login(self):
+        """Login to the API."""
+        return await self._auth.send_login_request()

--- a/pyanglianwater/exceptions.py
+++ b/pyanglianwater/exceptions.py
@@ -36,6 +36,9 @@ class ConfirmationRedirectError(AuthError):
 class TokenRequestError(AuthError):
     """Error requesting a token from the token server."""
 
+class InvalidAccountIdError(AuthError):
+    """403 Invalid account ID."""
+
 API_RESPONSE_STATUS_CODE_MAPPING = {
     "E_LGN_006": InvalidPasswordError,
     "E_LGN_008": InvalidUsernameError,

--- a/test.py
+++ b/test.py
@@ -20,10 +20,12 @@ async def main():
             authenticator = MSOB2CAuth(
                 username=os.environ.get("AW_USERNAME") or input("Email: "),
                 password=os.environ.get("AW_PASSWORD") or input("Password: "),
-                account_id=os.environ.get("AW_ACCOUNT_ID") or input("Account ID: ")
+                account_id=os.environ.get("AW_ACCOUNT_ID") or input("Account ID: "),
+                refresh_token=os.environ.get("AW_REFRESH_TOKEN", None),
             )
             await authenticator.send_login_request()
             _LOGGER.debug("Logged in. Ready..")
+            _LOGGER.debug("Refresh token: %s", authenticator.refresh_token)
             login = False
         except Exception as exc:
             _LOGGER.error(exc)


### PR DESCRIPTION
Properly implement token refresh so login can happen without the need to spoof a full OAuth flow each time.