### PR TITLE
Revert to using extension_accountNumber for account retrieval

### DIFF
--- a/pyanglianwater/auth.py
+++ b/pyanglianwater/auth.py
@@ -98,7 +98,7 @@ class MSOB2CAuth(BaseAuth):
         if self._account_number is not None:
             return encrypt_string_to_charcode_hex(self._account_number)
         return encrypt_string_to_charcode_hex(
-            self._decoded_access_token.get("extension_defaultAccountNumber", "")
+            self._decoded_access_token.get("extension_accountNumber", "")
         )
 
     @property


### PR DESCRIPTION
Change the account number retrieval to use `extension_accountNumber` instead of `extension_defaultAccountNumber`