### PR TITLE
Enhance authentication error handling and add tests for consent requirements

### DIFF
--- a/pyanglianwater/auth.py
+++ b/pyanglianwater/auth.py
@@ -70,6 +70,7 @@ ENTRA_ERROR_HINTS = {
     "AADSTS50079": InteractionRequiredError,  # MFA registration required
     "AADB2C90091": AccessDeniedError,  # User cancelled flow
     "AADB2C90118": InteractionRequiredError,  # Password reset requested
+    "AADB2C90080": InvalidGrantError,  # Refresh token expired due to inactivity
 }
 
 
@@ -226,6 +227,13 @@ class MSOB2CAuth:
             AUTH_MSO_CONFIRM_URL.format(CSRF=self._csrf_token, STATE=self._state),
             allow_redirects=False,
         )
+
+        if confirm_login_response.status == 200:
+            text = await confirm_login_response.text()
+            terms_of_use_match = re.search(r'"ID":"extension_termsOfUseConsentChoice"', text)
+            is_req_match = re.search(r'"IS_REQ":true', text)
+            if terms_of_use_match and is_req_match:
+                raise ConsentRequiredError("Terms of use not accepted")
 
         if confirm_login_response.status != 302:
             text = await confirm_login_response.text()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -81,6 +81,21 @@ async def test_get_confirmation_redirect(auth_instance):  # pylint: disable=rede
         location = await auth_instance._get_confirmation_redirect()  # pylint: disable=protected-access
         assert location == "https://example.com"
 
+@pytest.mark.asyncio
+async def test_get_confirmation_redirect_terms_of_use_not_accepted(auth_instance):  # pylint: disable=redefined-outer-name
+    """
+    Test the _get_confirmation_redirect method raises ConsentRequiredError
+    when terms of use are not accepted.
+    """
+    with patch(  # pylint: disable=protected-access
+        "pyanglianwater.auth.aiohttp.ClientSession.get", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value.status = 200
+        mock_get.return_value.text = AsyncMock(
+            return_value='{"ID":"extension_termsOfUseConsentChoice", "IS_REQ":true}'
+        )
+        with pytest.raises(ConsentRequiredError):
+            await auth_instance._get_confirmation_redirect()  # pylint: disable=protected-access
 
 @pytest.mark.asyncio
 async def test_get_token(auth_instance):  # pylint: disable=redefined-outer-name
@@ -259,6 +274,11 @@ def test_raise_mapped_token_error_oauth_codes(error_code, expected_exception):
     "error_message,error_codes,expected_exception",
     [
         ("AADSTS700082: Refresh token expired", None, InvalidGrantError),
+        (
+            "AADB2C90080: The provided grant has expired. Please re-authenticate and try again",
+            None,
+            InvalidGrantError
+        ),
         ("AADSTS65001: Consent required", None, ConsentRequiredError),
         ("AADSTS50076: MFA required", None, InteractionRequiredError),
         ("AADSTS50079: MFA registration required", None, InteractionRequiredError),


### PR DESCRIPTION
- Added handling for "AADB2C90080" error to raise InvalidGrantError when the refresh token is expired due to inactivity.
- Implemented a check in the _get_confirmation_redirect method to raise ConsentRequiredError if terms of use are not accepted.
- Added a new test case to verify that ConsentRequiredError is raised when terms of use are not accepted.

Fixes: https://github.com/home-assistant/core/issues/173437 https://github.com/home-assistant/core/issues/174410