### PR TITLE
Add MFA handling to authentication flow

### DIFF
--- a/pyanglianwater/auth.py
+++ b/pyanglianwater/auth.py
@@ -16,6 +16,8 @@ from .const import (
     AUTH_MSO_GET_TOKEN_URL,
     AUTH_AW_BASE,
     AUTH_MSO_CONFIRM_URL,
+    AUTH_MSO_CONFIRM_URL_NO_REMEMBER,
+    AUTH_MSO_SELF_ASSERTED_CONFIRM_URL,
     AUTH_MSO_CLIENT_ID,
     AUTH_MSO_REDIR_URI,
     AW_APP_USER_AGENT,
@@ -36,6 +38,8 @@ from .exceptions import (
     ConsentRequiredError,
     TemporarilyUnavailableError,
     SelfAssertedError,
+    MFARequiredError,
+    ConfirmationRedirectError,
     TokenRequestError,
 )
 from .utils import (
@@ -87,6 +91,9 @@ class MSOB2CAuth:
     _state = secrets.token_urlsafe(32)
     _csrf_token: str = ""
     _cookie_cache: dict = {}
+    _trans_id: str | None = None
+    _mfa_readonly_email: str | None = None
+    _mfa_pending: bool = False
 
     def __init__(self, username, password, session=None, refresh_token=None):
         if session:
@@ -220,6 +227,100 @@ class MSOB2CAuth:
 
         return asserted_login_response
 
+    def _is_mfa_challenge_page(self, html: str) -> bool:
+        """Heuristically determine whether the confirmed page asks for MFA."""
+        # In the observed HTML, MFA is signalled via `2fa_login_challenge.html`
+        # and the presence of a `verificationCode` input definition.
+        if re.search(r"2fa[_-]login[_-]challenge\.html", html, flags=re.I):
+            return True
+        if re.search(r"\b2fa\b", html, flags=re.I) and re.search(
+            r'"ID"\s*:\s*"verificationCode"', html, flags=re.I
+        ):
+            return True
+        return False
+
+    def _extract_readonly_email_from_mfa_html(self, html: str) -> str | None:
+        """Extract readonlyEmail from the MFA page HTML."""
+        # Observed in HTML as:
+        # { ... "ID":"readonlyEmail", "PRE":"jordan@hrvy.uk", ...}
+        match = re.search(
+            r'"ID"\s*:\s*"readonlyEmail".{0,800}?"PRE"\s*:\s*"([^"]+?)"',
+            html,
+            flags=re.I | re.S,
+        )
+        if match:
+            return match.group(1)
+        return None
+
+    def _extract_mfa_csrf_from_mfa_html(self, html: str) -> str | None:
+        """Extract SETTINGS.csrf from MFA challenge HTML."""
+        # Observed in the MFA challenge HTML as:
+        # var SETTINGS = {...,"csrf":"<value>",...};
+        match = re.search(
+            r'var\s+SETTINGS\s*=\s*\{.*?"csrf"\s*:\s*"([^"]+?)"',
+            html,
+            flags=re.I | re.S,
+        )
+        if match:
+            return match.group(1)
+        return None
+
+    async def _submit_mfa_self_asserted_form(
+        self, trans_id: str, verification_code: str
+    ):
+        """Submits the MFA SelfAsserted form (second POST after the challenge)."""
+        if not self._mfa_readonly_email:
+            raise ValueError("MFA readonlyEmail not available; resume after MFARequiredError")
+
+        _LOGGER.debug("B2C Auth: Submitting MFA self-asserted form")
+        data = {
+            "request_type": "RESPONSE",
+            "readonlyEmail": self._mfa_readonly_email,
+            "verificationCode": verification_code,
+        }
+
+        asserted_login_response = await self._auth_session.post(
+            AUTH_MSO_SELF_ASSERTED_URL.format(STATE=trans_id),
+            headers={
+                "X-CSRF-TOKEN": self._csrf_token,
+                # The confirmed endpoint is what surfaces the MFA challenge,
+                # so we use it as referer for the follow-up verification POST.
+                "Referer": AUTH_MSO_CONFIRM_URL_NO_REMEMBER.format(
+                    CSRF=self._csrf_token,
+                    STATE=self._state,
+                ),
+                "Origin": AUTH_AW_BASE,
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "User-Agent": AW_APP_USER_AGENT,
+            },
+            data=data,
+        )
+
+        try:
+            data = await asserted_login_response.json(content_type="text/json")
+        except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+            text = await asserted_login_response.text()
+            _LOGGER.error(
+                "B2C Auth: MFA SelfAsserted returned non-JSON (%s): %s",
+                asserted_login_response.status,
+                text,
+            )
+            raise SelfAssertedError(
+                f"Unexpected MFA response ({asserted_login_response.status})"
+            ) from e
+        status = int(data.get("status"))
+        if asserted_login_response.status != 200 or status != 200:
+            _LOGGER.error(
+                "B2C Auth: MFA SelfAsserted request failed %s: %s",
+                asserted_login_response.status,
+                data,
+            )
+            raise SelfAssertedError(
+                f"{data.get('errorCode', 'Unknown')} {data.get('message', 'Unknown')}"
+            )
+
+        return asserted_login_response
+
     async def _get_confirmation_redirect(self):
         """Gets the confirmation redirect URL."""
         _LOGGER.debug("B2C Auth: Getting confirmation redirect URL")
@@ -230,10 +331,29 @@ class MSOB2CAuth:
 
         if confirm_login_response.status == 200:
             text = await confirm_login_response.text()
-            terms_of_use_match = re.search(r'"ID":"extension_termsOfUseConsentChoice"', text)
-            is_req_match = re.search(r'"IS_REQ":true', text)
+
+            terms_of_use_match = re.search(
+                r'"ID"\s*:\s*"extension_termsOfUseConsentChoice"', text
+            )
+            is_req_match = re.search(r'"IS_REQ"\s*:\s*true', text)
             if terms_of_use_match and is_req_match:
                 raise ConsentRequiredError("Terms of use not accepted")
+
+            if self._is_mfa_challenge_page(text):
+                readonly_email = self._extract_readonly_email_from_mfa_html(text)
+                # MFA uses a *different* CSRF token for the verification POST and the
+                # subsequent SelfAsserted confirmation redirect.
+                mfa_csrf = self._extract_mfa_csrf_from_mfa_html(text)
+                if mfa_csrf:
+                    self._csrf_token = mfa_csrf
+                self._mfa_readonly_email = readonly_email
+                self._mfa_pending = True
+                raise MFARequiredError(readonly_email=readonly_email)
+            # Not a redirect and not the MFA challenge page: treat as failure
+            # so callers don't silently proceed without an access token.
+            raise ConfirmationRedirectError(
+                "Confirmed endpoint returned a 200 response but no redirect URL was provided"
+            )
 
         if confirm_login_response.status != 302:
             text = await confirm_login_response.text()
@@ -242,12 +362,43 @@ class MSOB2CAuth:
                 confirm_login_response.status,
                 text,
             )
-            return None
+            raise ConfirmationRedirectError(
+                f"Confirmed endpoint returned status {confirm_login_response.status}"
+            )
 
         location = confirm_login_response.headers.get("Location")
         if not location:
             _LOGGER.error("B2C Auth: Location header not found")
-            return None
+            raise ConfirmationRedirectError("Location header not found on confirmed redirect")
+
+        return location
+
+    async def _get_self_asserted_confirmation_redirect(self) -> str:
+        """After MFA verification, confirmed redirect is served by SelfAsserted."""
+        _LOGGER.debug("B2C Auth: Getting self-asserted confirmation redirect URL")
+        confirm_login_response = await self._auth_session.get(
+            AUTH_MSO_SELF_ASSERTED_CONFIRM_URL.format(
+                CSRF=self._csrf_token, STATE=self._state
+            ),
+            allow_redirects=False,
+        )
+
+        if confirm_login_response.status != 302:
+            text = await confirm_login_response.text()
+            _LOGGER.error(
+                "B2C Auth: SelfAsserted confirm request failed %s: %s",
+                confirm_login_response.status,
+                text,
+            )
+            raise ConfirmationRedirectError(
+                f"SelfAsserted confirm returned {confirm_login_response.status}"
+            )
+
+        location = confirm_login_response.headers.get("Location")
+        if not location:
+            raise ConfirmationRedirectError(
+                "Location header not found on SelfAsserted confirmation"
+            )
 
         return location
 
@@ -384,6 +535,11 @@ class MSOB2CAuth:
 
     async def send_login_request(self):
         """Send a request to MSO for Auth."""
+        # Clear any previous pending MFA state from earlier attempts.
+        self._mfa_pending = False
+        self._mfa_readonly_email = None
+        self._trans_id = None
+
         if self._refresh_token is not None:
             _LOGGER.debug("B2C Auth: Using refresh token for authentication")
             # Attempt to use refresh token first
@@ -397,6 +553,7 @@ class MSOB2CAuth:
             return
         if isinstance(auth_data, tuple):
             self._csrf_token, trans_id = auth_data
+            self._trans_id = trans_id
             asserted_response = await self._submit_self_asserted_form(trans_id)
             if asserted_response is None:
                 return
@@ -425,6 +582,41 @@ class MSOB2CAuth:
             "B2C Auth: Access token obtained successfully, new expiration time: %s",
             self.next_refresh,
         )
+
+    async def send_mfa_request(self, verification_code: str) -> None:
+        """Resume the MFA flow by submitting the verification code."""
+        if not self._mfa_pending or not self._trans_id:
+            raise ValueError("MFA not pending; call send_login_request() first")
+        if not self._csrf_token:
+            raise ValueError("Missing CSRF token; call send_login_request() first")
+
+        # Submit the MFA code
+        await self._submit_mfa_self_asserted_form(self._trans_id, verification_code)
+
+        # Confirmation should now complete with a 302 redirect containing the auth code.
+        redirect_location = await self._get_self_asserted_confirmation_redirect()
+
+        _, code = decode_oauth_redirect(redirect_location)
+        if not code:
+            _LOGGER.error("B2C Auth: Code not found after MFA")
+            raise ConfirmationRedirectError("Auth code not found after MFA")
+
+        token_response = await self._get_token(code)
+        if token_response is None:
+            _LOGGER.error("B2C Auth: Token request failed after MFA")
+            raise TokenRequestError("Token request failed after MFA")
+
+        self.auth_data = token_response
+        self.next_refresh = datetime.now() + timedelta(
+            seconds=token_response["expires_in"]
+        )
+        self._refresh_token = token_response.get("refresh_token")
+        self.auth_data = {**self.auth_data, **decode_jwt(self.access_token)}
+
+        # MFA is satisfied; clear pending state.
+        self._mfa_pending = False
+        self._mfa_readonly_email = None
+        self._trans_id = None
 
     async def send_request(
         self, method: str, url: str, body: dict | None, headers: dict

--- a/pyanglianwater/auth.py
+++ b/pyanglianwater/auth.py
@@ -591,7 +591,17 @@ class MSOB2CAuth:
             raise ValueError("Missing CSRF token; call send_login_request() first")
 
         # Submit the MFA code
-        await self._submit_mfa_self_asserted_form(self._trans_id, verification_code)
+        try:
+            await self._submit_mfa_self_asserted_form(
+                self._trans_id, verification_code
+            )
+        except SelfAssertedError as exc:
+            # Browser stays on the MFA step for invalid/expired codes.
+            # Re-signal the MFA requirement so callers can prompt again
+            # without restarting the login flow.
+            raise MFARequiredError(
+                readonly_email=self._mfa_readonly_email
+            ) from exc
 
         # Confirmation should now complete with a 302 redirect containing the auth code.
         redirect_location = await self._get_self_asserted_confirmation_redirect()

--- a/pyanglianwater/auth.py
+++ b/pyanglianwater/auth.py
@@ -256,13 +256,22 @@ class MSOB2CAuth:
         """Extract SETTINGS.csrf from MFA challenge HTML."""
         # Observed in the MFA challenge HTML as:
         # var SETTINGS = {...,"csrf":"<value>",...};
-        match = re.search(
-            r'var\s+SETTINGS\s*=\s*\{.*?"csrf"\s*:\s*"([^"]+?)"',
+        # Use a bounded match first to avoid scanning the entire HTML document.
+        settings_match = re.search(
+            r"var\s+SETTINGS\s*=\s*\{([^;]+)\};",
             html,
             flags=re.I | re.S,
         )
-        if match:
-            return match.group(1)
+        if not settings_match:
+            return None
+
+        csrf_match = re.search(
+            r'"csrf"\s*:\s*"([^"]+?)"',
+            settings_match.group(1),
+            flags=re.I,
+        )
+        if csrf_match:
+            return csrf_match.group(1)
         return None
 
     async def _submit_mfa_self_asserted_form(
@@ -298,17 +307,24 @@ class MSOB2CAuth:
 
         try:
             data = await asserted_login_response.json(content_type="text/json")
-        except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+            if not isinstance(data, dict) or "status" not in data:
+                raise ValueError("Missing status in MFA response")
+            status = int(data["status"])
+        except (
+            aiohttp.ContentTypeError,
+            json.JSONDecodeError,
+            ValueError,
+            TypeError,
+        ) as e:
             text = await asserted_login_response.text()
             _LOGGER.error(
-                "B2C Auth: MFA SelfAsserted returned non-JSON (%s): %s",
+                "B2C Auth: MFA SelfAsserted returned invalid response (%s): %s",
                 asserted_login_response.status,
                 text,
             )
             raise SelfAssertedError(
                 f"Unexpected MFA response ({asserted_login_response.status})"
             ) from e
-        status = int(data.get("status"))
         if asserted_login_response.status != 200 or status != 200:
             _LOGGER.error(
                 "B2C Auth: MFA SelfAsserted request failed %s: %s",
@@ -573,11 +589,15 @@ class MSOB2CAuth:
             return
 
         self.auth_data = token_response
-        self.next_refresh = datetime.now() + timedelta(
-            seconds=token_response["expires_in"]
-        )
+        try:
+            expires_in = int(token_response.get("expires_in", 3600))
+        except (ValueError, TypeError):
+            expires_in = 3600
+        self.next_refresh = datetime.now() + timedelta(seconds=expires_in)
         self._refresh_token = token_response.get("refresh_token")
-        self.auth_data = {**self.auth_data, **decode_jwt(self.access_token)}
+        access_token = self.access_token
+        if access_token:
+            self.auth_data = {**self.auth_data, **decode_jwt(access_token)}
         _LOGGER.debug(
             "B2C Auth: Access token obtained successfully, new expiration time: %s",
             self.next_refresh,
@@ -617,11 +637,15 @@ class MSOB2CAuth:
             raise TokenRequestError("Token request failed after MFA")
 
         self.auth_data = token_response
-        self.next_refresh = datetime.now() + timedelta(
-            seconds=token_response["expires_in"]
-        )
+        try:
+            expires_in = int(token_response.get("expires_in", 3600))
+        except (ValueError, TypeError):
+            expires_in = 3600
+        self.next_refresh = datetime.now() + timedelta(seconds=expires_in)
         self._refresh_token = token_response.get("refresh_token")
-        self.auth_data = {**self.auth_data, **decode_jwt(self.access_token)}
+        access_token = self.access_token
+        if access_token:
+            self.auth_data = {**self.auth_data, **decode_jwt(access_token)}
 
         # MFA is satisfied; clear pending state.
         self._mfa_pending = False

--- a/pyanglianwater/const.py
+++ b/pyanglianwater/const.py
@@ -67,6 +67,17 @@ AUTH_MSO_CONFIRM_URL = (
     f"{AUTH_MSO_BASE}/api/CombinedSigninAndSignup/confirmed?rememberMe=true&"
     "csrf_token={CSRF}&tx={STATE}&p=B2C_1A_SignUpOrSignIn"
 )
+
+# Browser uses rememberMe=false during the MFA transition referer.
+AUTH_MSO_CONFIRM_URL_NO_REMEMBER = (
+    f"{AUTH_MSO_BASE}/api/CombinedSigninAndSignup/confirmed?rememberMe=false&"
+    "csrf_token={CSRF}&tx={STATE}&p=B2C_1A_SignUpOrSignIn"
+)
+
+# After successful MFA, the browser transitions via the SelfAsserted confirmed endpoint.
+AUTH_MSO_SELF_ASSERTED_CONFIRM_URL = (
+    f"{AUTH_MSO_BASE}/api/SelfAsserted/confirmed?csrf_token={{CSRF}}&tx={{STATE}}&p=B2C_1A_SignUpOrSignIn"
+)
 AUTH_MSO_OAUTH_SERVICE = (
     "https://customeronlinejourney.b2clogin.com/customeronlinejourney.onmicrosoft.com/"
     "B2C_1A_SIGNUPORSIGNIN/oauth2/v2.0"

--- a/pyanglianwater/exceptions.py
+++ b/pyanglianwater/exceptions.py
@@ -86,6 +86,18 @@ class SelfAssertedError(AuthError):
     """Error performing login via username and password."""
 
 
+class MFARequiredError(AuthError):
+    """2FA/MFA is required to complete the login flow.
+
+    When raised, the caller should prompt the user for the verification code
+    and resume the auth flow by calling `MSOB2CAuth.send_mfa_request()`.
+    """
+
+    def __init__(self, message: str = "MFA required", readonly_email: str | None = None):
+        super().__init__(message)
+        self.readonly_email = readonly_email
+
+
 class ConfirmationRedirectError(AuthError):
     """Error confirming login with redirect."""
 

--- a/test.py
+++ b/test.py
@@ -9,6 +9,7 @@ import aiohttp
 from dotenv import load_dotenv
 from pyanglianwater import AnglianWater
 from pyanglianwater.auth import MSOB2CAuth
+from pyanglianwater.exceptions import MFARequiredError
 
 _LOGGER = logging.getLogger(__name__)
 load_dotenv()
@@ -32,7 +33,23 @@ async def main():
             _LOGGER.debug("Refresh token: %s", authenticator.refresh_token)
             _LOGGER.debug("Access token: %s", authenticator.access_token)
             login = False
-        except Exception as exc:
+        except MFARequiredError as exc:
+            readonly_email = exc.readonly_email
+            while True:
+                code = input(
+                    "Enter MFA verification code"
+                    f"{' for ' + readonly_email if readonly_email else ''}: "
+                )
+                try:
+                    await authenticator.send_mfa_request(code)
+                    _LOGGER.debug("Logged in with MFA. Ready..")
+                    _LOGGER.debug("Refresh token: %s", authenticator.refresh_token)
+                    _LOGGER.debug("Access token: %s", authenticator.access_token)
+                    login = False
+                    break
+                except MFARequiredError:
+                    _LOGGER.error("MFA code was rejected/expired. Please try again.")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             _LOGGER.error(exc)
 
     water = AnglianWater(authenticator)
@@ -56,5 +73,4 @@ if __name__ == "__main__":
         format="%(asctime)s %(name)s %(levelname)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,6 +14,7 @@ from pyanglianwater.exceptions import (
     ExpiredAccessTokenError,
     InteractionRequiredError,
     MFARequiredError,
+    SelfAssertedError,
     InvalidAccountIdError,
     InvalidClientError,
     InvalidGrantError,
@@ -383,3 +384,23 @@ async def test_send_mfa_request_resumes_and_clears_state(auth_instance):  # pyli
     assert not auth_instance._mfa_pending  # pylint: disable=protected-access
     assert auth_instance._mfa_readonly_email is None  # pylint: disable=protected-access
     assert auth_instance._trans_id is None  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_send_mfa_request_invalid_code_prompts_again(auth_instance):  # pylint: disable=redefined-outer-name
+    """Invalid/expired MFA codes should raise MFARequiredError for retry."""
+    auth_instance._mfa_pending = True  # pylint: disable=protected-access
+    auth_instance._trans_id = "trans_id"  # pylint: disable=protected-access
+    auth_instance._csrf_token = "csrf"  # pylint: disable=protected-access
+    auth_instance._mfa_readonly_email = "test@example.com"  # pylint: disable=protected-access
+
+    with (
+        patch.object(
+            auth_instance,
+            "_submit_mfa_self_asserted_form",  # pylint: disable=protected-access
+            AsyncMock(side_effect=SelfAssertedError("invalid_code")),
+        ),
+    ):
+        with pytest.raises(MFARequiredError) as excinfo:
+            await auth_instance.send_mfa_request("123456")
+        assert excinfo.value.readonly_email == "test@example.com"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,6 +13,7 @@ from pyanglianwater.exceptions import (
     ConsentRequiredError,
     ExpiredAccessTokenError,
     InteractionRequiredError,
+    MFARequiredError,
     InvalidAccountIdError,
     InvalidClientError,
     InvalidGrantError,
@@ -327,3 +328,58 @@ def test_raise_mapped_token_error_real_invalid_grant_refresh_fixture(
             response_text=refresh_invalid_grant_response_text,
         )
     assert "AADB2C90080" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_confirmation_redirect_raises_mfa_required(auth_instance):  # pylint: disable=redefined-outer-name
+    """MFA challenges should raise MFARequiredError (confirmed returns 200)."""
+    mfa_html = (
+        '<script>var SETTINGS = {"remoteResource":"https://example/2fa_login_challenge.html"};</script>'
+        '{"AttributeFields":[{"ID":"readonlyEmail","PRE":"test@example.com"},{"ID":"verificationCode"}]}'
+    )
+    with patch(
+        "pyanglianwater.auth.aiohttp.ClientSession.get",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        mock_get.return_value.status = 200
+        mock_get.return_value.text = AsyncMock(return_value=mfa_html)
+
+        with pytest.raises(MFARequiredError) as exc:
+            await auth_instance._get_confirmation_redirect()  # pylint: disable=protected-access
+        assert exc.value.readonly_email == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_send_mfa_request_resumes_and_clears_state(auth_instance):  # pylint: disable=redefined-outer-name
+    """send_mfa_request should complete auth and clear pending state."""
+    auth_instance._mfa_pending = True  # pylint: disable=protected-access
+    auth_instance._trans_id = "trans_id"  # pylint: disable=protected-access
+    auth_instance._csrf_token = "csrf"  # pylint: disable=protected-access
+    auth_instance._mfa_readonly_email = "test@example.com"  # pylint: disable=protected-access
+
+    with (
+        patch.object(
+            auth_instance,
+            "_submit_mfa_self_asserted_form",  # pylint: disable=protected-access
+            AsyncMock(),
+        ) as mock_submit,
+        patch.object(
+            auth_instance,
+            "_get_self_asserted_confirmation_redirect",  # pylint: disable=protected-access
+            AsyncMock(
+                return_value="uk.co.anglianwater.myaccount://oauth?code=test_code&state=test_state"
+            ),
+        ),
+        patch.object(
+            auth_instance,
+            "_get_token",  # pylint: disable=protected-access
+            AsyncMock(return_value={"access_token": "test_access", "expires_in": 3600, "refresh_token": "r"}),
+        ),
+    ):
+        await auth_instance.send_mfa_request("123456")
+
+    mock_submit.assert_awaited_once_with("trans_id", "123456")
+    assert auth_instance.access_token == "test_access"
+    assert not auth_instance._mfa_pending  # pylint: disable=protected-access
+    assert auth_instance._mfa_readonly_email is None  # pylint: disable=protected-access
+    assert auth_instance._trans_id is None  # pylint: disable=protected-access


### PR DESCRIPTION
- Introduced MFARequiredError to manage multi-factor authentication requirements during login.
- Updated the MSOB2CAuth class to handle MFA challenges, including extracting readonly email and CSRF tokens.
- Enhanced the main function in test.py to prompt for MFA verification code when required.
- Added tests to ensure proper handling of MFA scenarios and state management.

This update improves the security of the authentication process by enforcing MFA where necessary.

Addresses: https://github.com/home-assistant/core/issues/174410#issuecomment-4892653419