### PR TITLE
Enhance account summary API request with additional query parameters

### DIFF
--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -110,9 +110,9 @@ class AnglianWater:
                 endpoint="get_account_summary",
                 body=None,
                 account_number=account_number,
-                HAS_PAYMENT_ARRANGEMENT=self.account_config.get("has_payment_arrangement", "false"),
-                HAS_FUTURE_MOVE_IN=self.account_config.get("has_future_move_in", "false"),
-                HAS_COURT_ACCOUNT=self.account_config.get("has_court_account", "false"),
+                HAS_PAYMENT_ARRANGEMENT=str(self.account_config.get("has_payment_arrangement", False)).lower(),
+                HAS_FUTURE_MOVE_IN=str(self.account_config.get("has_future_move_in", False)).lower(),
+                HAS_COURT_ACCOUNT=str(self.account_config.get("has_court_account", False)).lower(),
             )
         except UnknownEndpointError as exc:
             if exc.status >= 500:

--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -110,6 +110,9 @@ class AnglianWater:
                 endpoint="get_account_summary",
                 body=None,
                 account_number=account_number,
+                HAS_PAYMENT_ARRANGEMENT=self.account_config.get("has_payment_arrangement", "false"),
+                HAS_FUTURE_MOVE_IN=self.account_config.get("has_future_move_in", "false"),
+                HAS_COURT_ACCOUNT=self.account_config.get("has_court_account", "false"),
             )
         except UnknownEndpointError as exc:
             if exc.status >= 500:
@@ -144,7 +147,7 @@ class AnglianWater:
             self._first_update = False
         await self.get_comparison(account_number)
         await self.get_usages(account_number)
-        # await self.get_billing_summary(account_number)
+        await self.get_billing_summary(account_number)
         for callback in self.updated_data_callbacks:
             if is_awaitable(callback):
                 await callback()

--- a/pyanglianwater/const.py
+++ b/pyanglianwater/const.py
@@ -15,7 +15,14 @@ AW_APP_ENDPOINTS = {
     },
     "get_account_summary": {
         "method": "GET",
-        "endpoint": "/myaccount/v1/accounts/{ACCOUNT_ID}/billing/summary",
+        # The backend expects these query parameters; omitting them may yield
+        # a 400 validation error (e.g. "Has Payment Arrangement must not be empty").
+        "endpoint": (
+            "/myaccount/v1/accounts/{ACCOUNT_ID}/billing/summary"
+            "?haspaymentarrangement={HAS_PAYMENT_ARRANGEMENT}"
+            "&hasfuturemovein={HAS_FUTURE_MOVE_IN}"
+            "&hascourtaccount={HAS_COURT_ACCOUNT}"
+        ),
     },
     "get_usage_costs": {
         "method": "GET",


### PR DESCRIPTION
- Added support for HAS_PAYMENT_ARRANGEMENT, HAS_FUTURE_MOVE_IN, and HAS_COURT_ACCOUNT query parameters in the get_account_summary endpoint to prevent validation errors.
- Updated the endpoint definition to include these parameters in the request URL.
- Re-enabled the get_billing_summary call in the AnglianWater class to ensure billing data is retrieved as part of the account summary process.