### PR TITLE
Treat 5xx from costs and billing summary endpoints as unavailable data

### DIFF
--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -80,9 +80,10 @@ class AnglianWater:
                 END=(start + timedelta(days=1)).isoformat(),
             )
         except UnknownEndpointError as exc:
-            if exc.status >= 500:
-                raise
-
+            # The costs endpoint returns a 500 with an empty errors array when
+            # no cost data exists for the requested window (data is published
+            # ~3 days behind), so server errors are treated as "unavailable"
+            # rather than fatal.
             _costs = {}
             _LOGGER.exception(
                 "Usage costs not available for account %s - %s (%s)",
@@ -115,9 +116,9 @@ class AnglianWater:
                 HAS_COURT_ACCOUNT=str(self.account_config.get("has_court_account", False)).lower(),
             )
         except UnknownEndpointError as exc:
-            if exc.status >= 500:
-                raise
-
+            # Treat server errors the same as client errors here: the backend
+            # can 500 when summary data is unavailable, and billing must not
+            # fail the wider update cycle.
             _LOGGER.exception(
                 "Billing summary not available for account %s (%s)",
                 account_number,

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -12,6 +12,7 @@ from pyanglianwater import (
     UsageComparison,
 )
 from pyanglianwater.auth import MSOB2CAuth
+from pyanglianwater.exceptions import UnknownEndpointError
 
 
 @pytest.fixture
@@ -83,6 +84,44 @@ async def test_get_usages(anglian_water):  # pylint: disable=redefined-outer-nam
     result = await anglian_water.get_usages(account_number=account_number, update_cache=False)
     assert "12345" in anglian_water.meters
     assert isinstance(result, (dict, list))
+
+
+@pytest.mark.asyncio
+async def test_get_usages_costs_server_error(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that get_usages still returns usage data when the costs endpoint returns a 5xx.
+
+    The costs endpoint 500s whenever the requested window has no cost data yet
+    (Anglian Water publish cost data ~3 days behind), so a server error must not
+    prevent meter readings from being parsed.
+    """
+    account_number = "12345"
+    usage_response = {
+        "result": {
+            "records": [
+                {
+                    "meters": [
+                        {
+                            "meter_serial_number": "12345",
+                            "read": 100.0,
+                            "consumption": 10.0,
+                            "read_at": "2023-10-01T00:00:00Z",
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=[
+            usage_response,
+            UnknownEndpointError(500, '{"result":{"errors":[]}}'),
+        ]
+    )
+    result = await anglian_water.get_usages(account_number=account_number)
+    assert "12345" in anglian_water.meters
+    assert isinstance(result, (dict, list))
+    assert anglian_water.meters["12345"].yesterday_water_cost == 0.0
+    assert anglian_water.meters["12345"].yesterday_sewerage_cost == 0.0
 
 
 @pytest.mark.asyncio
@@ -326,6 +365,21 @@ async def test_get_billing_summary_no_arrangement(anglian_water):  # pylint: dis
     assert isinstance(result, BillingSummary)
     assert result.payment_arrangement is None
     assert result.account_balance == 0.00
+
+
+@pytest.mark.asyncio
+async def test_get_billing_summary_server_error(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that get_billing_summary treats a 5xx as unavailable instead of raising.
+
+    Mirrors the usage-costs behaviour: the backend can 500 when summary data
+    is not available, which must not fail the wider update cycle.
+    """
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=UnknownEndpointError(500, '{"result":{"errors":[]}}')
+    )
+    result = await anglian_water.get_billing_summary(account_number="12345")
+    assert result is None
+    assert anglian_water.billing is None
 
 
 def test_to_dict_includes_billing(anglian_water):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
## Problem

The usage costs endpoint (`/cost/usage/smart`) returns **HTTP 500 with an empty errors array** (`{"result":{"errors":[]}}`) whenever the requested window has no cost data yet. Anglian Water publish cost/usage data ~3 days behind real time, and `get_usages` always requests *yesterday's* costs — so in practice the costs call 500s on **every** update cycle.

Because `get_usages` re-raises `UnknownEndpointError` when `status >= 500`, the whole `update()` fails even though `get_usage_details` returned a full set of readings. Downstream this breaks the Home Assistant integration's entire coordinator refresh (all sensors, not just costs). The HA Core `anglian_water` component pins `pyanglianwater==3.2.4`, which contains this behaviour.

Verified against a live account by probing the endpoint with 1-day windows walking backwards: windows ending within the last ~3 days consistently 500; older windows return costs normally (or zeros at the boundary). Request format (frequency, timestamps, timezone) was ruled out — invalid values produce proper 400 validation errors instead.

## Change

- `get_usages`: stop re-raising 5xx from `get_usage_costs`; fall back to empty costs and log, matching the existing 4xx handling.
- `get_billing_summary`: remove the same `status >= 500` re-raise pattern so a billing 5xx cannot fail the update cycle either.
- Tests for both paths (usage parsing still succeeds with costs unavailable; billing summary returns `None` without raising).

Verified end-to-end against a live account: `update()` now completes with 312 hourly readings cached, comparison and billing populated, and costs zeroed with a logged warning.

## Possible follow-up (not in this PR)

`get_comparison` has no error handling at all, so a 5xx there would still fail `update()`. If the comparison endpoint exhibits the same "500 = no data" behaviour it may deserve similar treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)