### PR TITLE
Fetch usage costs per day for the readings window

### DIFF
--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -80,9 +80,10 @@ class AnglianWater:
                 END=(start + timedelta(days=1)).isoformat(),
             )
         except UnknownEndpointError as exc:
-            if exc.status >= 500:
-                raise
-
+            # The costs endpoint returns a 500 with an empty errors array when
+            # no cost data exists for the requested window (data is published
+            # ~3 days behind), so server errors are treated as "unavailable"
+            # rather than fatal.
             _costs = {}
             _LOGGER.exception(
                 "Usage costs not available for account %s - %s (%s)",
@@ -115,9 +116,9 @@ class AnglianWater:
                 HAS_COURT_ACCOUNT=str(self.account_config.get("has_court_account", False)).lower(),
             )
         except UnknownEndpointError as exc:
-            if exc.status >= 500:
-                raise
-
+            # Treat server errors the same as client errors here: the backend
+            # can 500 when summary data is unavailable, and billing must not
+            # fail the wider update cycle.
             _LOGGER.exception(
                 "Billing summary not available for account %s (%s)",
                 account_number,

--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -3,7 +3,7 @@
 import logging
 
 from typing import Callable
-from datetime import timedelta, datetime as dt
+from datetime import timedelta, datetime as dt, time as dt_time
 
 from .api import API
 from .auth import MSOB2CAuth
@@ -11,7 +11,7 @@ from .enum import UsagesReadGranularity
 from .exceptions import SmartMeterUnavailableError, UnknownEndpointError
 from .billing import BillingSummary
 from .meter import SmartMeter, UsageComparison
-from .utils import is_awaitable
+from .utils import is_awaitable, parse_iso_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ class AnglianWater:
         self.billing: BillingSummary | None = None
         self.updated_data_callbacks: list[Callable] = []
         self._first_update = True
+        self._daily_costs_cache: dict[str, dict] = {}
 
     @property
     def current_tariff(self) -> str:
@@ -63,35 +64,81 @@ class AnglianWater:
         update_cache: bool = True,
     ) -> dict:
         """Calculates the usage using the provided date range."""
-        start = dt.today().replace(hour=23, minute=0, second=0) - timedelta(days=1)
         _response = await self.api.send_request(
             endpoint="get_usage_details",
             body=None,
             account_number=account_number,
             GRANULARITY=str(interval),
         )
-        try:
-            _costs = await self.api.send_request(
-                endpoint="get_usage_costs",
-                body=None,
-                account_number=account_number,
-                GRANULARITY=str(interval),
-                START=start.isoformat(),
-                END=(start + timedelta(days=1)).isoformat(),
-            )
-        except UnknownEndpointError as exc:
-            # The costs endpoint returns a 500 with an empty errors array when
-            # no cost data exists for the requested window (data is published
-            # ~3 days behind), so server errors are treated as "unavailable"
-            # rather than fatal.
-            _costs = {}
-            _LOGGER.exception(
-                "Usage costs not available for account %s - %s (%s)",
-                account_number,
-                start,
-                exc.response,
-            )
+        records = _response
+        if isinstance(records, dict) and "result" in records:
+            records = records["result"]
+        if isinstance(records, dict) and "records" in records:
+            records = records["records"]
+        days = set()
+        for record in records or []:
+            for meter in record.get("meters", []):
+                read_at = parse_iso_datetime(meter.get("read_at", ""))
+                if read_at is not None:
+                    days.add(read_at.date())
+        _costs = await self._get_daily_costs(account_number, sorted(days), interval)
         return await self.parse_usages(_response, _costs, update_cache)
+
+    async def _get_daily_costs(
+        self,
+        account_number: str,
+        days: list,
+        interval: UsagesReadGranularity,
+    ) -> dict:
+        """Fetch usage costs for each given day, caching across updates.
+
+        Returns a map of ISO date -> {"total_cost", "water_cost",
+        "sewerage_cost"}. Days whose cost data is not yet published (the
+        endpoint returns a 500 with an empty errors array for those) are
+        skipped rather than treated as fatal.
+        """
+        costs: dict[str, dict] = {}
+        for day in days:
+            key = day.isoformat()
+            if key in self._daily_costs_cache:
+                costs[key] = self._daily_costs_cache[key]
+                continue
+            # The API groups a day's usage into the 23:00-to-23:00 window
+            # ending on that day.
+            start = dt.combine(day - timedelta(days=1), dt_time(23, 0))
+            try:
+                response = await self.api.send_request(
+                    endpoint="get_usage_costs",
+                    body=None,
+                    account_number=account_number,
+                    GRANULARITY=str(interval),
+                    START=start.isoformat(),
+                    END=(start + timedelta(days=1)).isoformat(),
+                )
+            except UnknownEndpointError as exc:
+                _LOGGER.debug(
+                    "Usage costs not available for account %s - %s (%s)",
+                    account_number,
+                    key,
+                    exc.response,
+                )
+                continue
+            result = response.get("result") if isinstance(response, dict) else None
+            if not isinstance(result, dict):
+                continue
+            entry = {
+                "total_cost": float(result.get("total_cost") or 0.0),
+                "water_cost": float(result.get("water_cost") or 0.0),
+                "sewerage_cost": float(result.get("sewerage_cost") or 0.0),
+            }
+            costs[key] = entry
+            self._daily_costs_cache[key] = entry
+        # Drop cached days that have fallen out of the readings window.
+        keep = {day.isoformat() for day in days}
+        self._daily_costs_cache = {
+            k: v for k, v in self._daily_costs_cache.items() if k in keep
+        }
+        return costs
 
     async def get_comparison(self, account_number: str) -> UsageComparison:
         """Get usage comparison data."""

--- a/pyanglianwater/meter.py
+++ b/pyanglianwater/meter.py
@@ -49,23 +49,80 @@ class SmartMeter:
     """
 
     last_reading: float = 0.0
-    yesterday_water_cost: float = 0.0
-    yesterday_sewerage_cost: float = 0.0
 
     def __init__(self, serial_number):
         self.serial_number = serial_number
         self.readings = []
+        self.daily_costs: dict[str, dict] = {}
 
     def update_reading_cache(self, reads: list, costs: dict):
-        """Updates the cache of meter reads for the smart meter."""
+        """Updates the cache of meter reads for the smart meter.
+
+        costs maps ISO dates to {"total_cost", "water_cost", "sewerage_cost"}
+        for each day cost data is available.
+        """
         self.readings = []
         for reading in reads:
             for meter in reading["meters"]:
                 if meter["meter_serial_number"] == self.serial_number:
                     self.readings.append({**meter})
                     self.last_reading = float(meter["read"])
-        self.yesterday_water_cost = costs.get("result", {}).get("water_cost", 0.0)
-        self.yesterday_sewerage_cost = costs.get("result", {}).get("sewerage_cost", 0.0)
+        self.daily_costs = dict(costs)
+
+    @property
+    def latest_cost_date(self) -> str | None:
+        """Returns the most recent ISO date with cost data available."""
+        if not self.daily_costs:
+            return None
+        return max(self.daily_costs)
+
+    @property
+    def yesterday_water_cost(self) -> float:
+        """Returns the water cost for the most recent day with cost data.
+
+        Cost data is published a few days behind readings, so this is the
+        latest available day rather than the literal calendar yesterday.
+        """
+        date = self.latest_cost_date
+        if date is None:
+            return 0.0
+        return float(self.daily_costs[date].get("water_cost", 0.0))
+
+    @property
+    def yesterday_sewerage_cost(self) -> float:
+        """Returns the sewerage cost for the most recent day with cost data."""
+        date = self.latest_cost_date
+        if date is None:
+            return 0.0
+        return float(self.daily_costs[date].get("sewerage_cost", 0.0))
+
+    def get_hourly_costs(self) -> list[dict]:
+        """Returns per-reading costs, distributing each day's total cost
+        across that day's readings in proportion to consumption."""
+        by_day: dict[str, list] = {}
+        for reading in self.readings:
+            read_at = parse_iso_datetime(reading["read_at"])
+            if read_at is None:
+                continue
+            by_day.setdefault(read_at.date().isoformat(), []).append(reading)
+        hourly = []
+        for day, rows in by_day.items():
+            costs = self.daily_costs.get(day)
+            if not costs:
+                continue
+            day_consumption = sum(float(r["consumption"]) for r in rows)
+            if day_consumption <= 0:
+                continue
+            day_total = float(costs.get("total_cost", 0.0))
+            for row in rows:
+                hourly.append(
+                    {
+                        "read_at": row["read_at"],
+                        "cost": day_total * float(row["consumption"]) / day_consumption,
+                    }
+                )
+        hourly.sort(key=lambda entry: entry["read_at"])
+        return hourly
 
     @property
     def get_yesterday_readings(self) -> list:
@@ -115,6 +172,7 @@ class SmartMeter:
             "last_reading": self.last_reading,
             "readings": self.readings,
             "consumption": self.latest_consumption,
+            "daily_costs": self.daily_costs,
         }
 
     def __iter__(self):

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -124,6 +124,121 @@ async def test_get_usages_costs_server_error(anglian_water):  # pylint: disable=
     assert anglian_water.meters["12345"].yesterday_sewerage_cost == 0.0
 
 
+_USAGE_TWO_DAYS = {
+    "result": {
+        "records": [
+            {
+                "date": "2026-07-15T01:00:00",
+                "meters": [
+                    {
+                        "meter_serial_number": "M1",
+                        "read": 10.1,
+                        "consumption": 100.0,
+                        "read_at": "2026-07-15T01:00:00",
+                    }
+                ],
+            },
+            {
+                "date": "2026-07-15T02:00:00",
+                "meters": [
+                    {
+                        "meter_serial_number": "M1",
+                        "read": 10.4,
+                        "consumption": 300.0,
+                        "read_at": "2026-07-15T02:00:00",
+                    }
+                ],
+            },
+            {
+                "date": "2026-07-16T01:00:00",
+                "meters": [
+                    {
+                        "meter_serial_number": "M1",
+                        "read": 10.5,
+                        "consumption": 100.0,
+                        "read_at": "2026-07-16T01:00:00",
+                    }
+                ],
+            },
+        ]
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_get_usages_fetches_costs_per_day(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that get_usages fetches costs for each day covered by the readings."""
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=[
+            _USAGE_TWO_DAYS,
+            {"result": {"total_cost": 2.0, "water_cost": 1.2, "sewerage_cost": 0.8}},
+            {"result": {"total_cost": 1.0, "water_cost": 0.6, "sewerage_cost": 0.4}},
+        ]
+    )
+    await anglian_water.get_usages(account_number="1")
+    meter = anglian_water.meters["M1"]
+    assert meter.daily_costs["2026-07-15"]["water_cost"] == 1.2
+    assert meter.daily_costs["2026-07-16"]["water_cost"] == 0.6
+    # yesterday_* now reflect the most recent day with cost data available
+    assert meter.yesterday_water_cost == 0.6
+    assert meter.yesterday_sewerage_cost == 0.4
+    # Cost windows follow the API's 23:00-to-23:00 day convention
+    first_cost_call = anglian_water.api.send_request.call_args_list[1]
+    assert first_cost_call.kwargs["START"] == "2026-07-14T23:00:00"
+    assert first_cost_call.kwargs["END"] == "2026-07-15T23:00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_usages_skips_unavailable_cost_days(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that a cost 5xx for one day does not lose other days or fail the update."""
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=[
+            _USAGE_TWO_DAYS,
+            {"result": {"total_cost": 2.0, "water_cost": 1.2, "sewerage_cost": 0.8}},
+            UnknownEndpointError(500, '{"result":{"errors":[]}}'),
+        ]
+    )
+    await anglian_water.get_usages(account_number="1")
+    meter = anglian_water.meters["M1"]
+    assert "2026-07-15" in meter.daily_costs
+    assert "2026-07-16" not in meter.daily_costs
+    # Falls back to the most recent day that does have data
+    assert meter.yesterday_water_cost == 1.2
+
+
+@pytest.mark.asyncio
+async def test_get_usages_caches_daily_costs(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that daily costs are cached and not refetched on subsequent updates."""
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=[
+            _USAGE_TWO_DAYS,
+            {"result": {"total_cost": 2.0, "water_cost": 1.2, "sewerage_cost": 0.8}},
+            {"result": {"total_cost": 1.0, "water_cost": 0.6, "sewerage_cost": 0.4}},
+            _USAGE_TWO_DAYS,
+        ]
+    )
+    await anglian_water.get_usages(account_number="1")
+    await anglian_water.get_usages(account_number="1")
+    # 1 usage + 2 costs on first update, 1 usage + 0 costs on second
+    assert anglian_water.api.send_request.call_count == 4
+    assert anglian_water.meters["M1"].daily_costs["2026-07-16"]["water_cost"] == 0.6
+
+
+def test_meter_hourly_costs():
+    """Test that hourly costs distribute each day's cost by consumption share."""
+    meter = SmartMeter(serial_number="M1")
+    meter.update_reading_cache(
+        _USAGE_TWO_DAYS["result"]["records"],
+        {"2026-07-15": {"total_cost": 2.0, "water_cost": 1.2, "sewerage_cost": 0.8}},
+    )
+    hourly = meter.get_hourly_costs()
+    # Only 2026-07-15 has cost data; its £2.00 splits 100L/300L -> £0.50/£1.50
+    assert len(hourly) == 2
+    assert hourly[0]["read_at"] == "2026-07-15T01:00:00"
+    assert hourly[0]["cost"] == pytest.approx(0.5)
+    assert hourly[1]["cost"] == pytest.approx(1.5)
+
+
 @pytest.mark.asyncio
 async def test_update(anglian_water):  # pylint: disable=redefined-outer-name
     """Test that update validates smart meter and fetches usage data."""

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -12,6 +12,7 @@ from pyanglianwater import (
     UsageComparison,
 )
 from pyanglianwater.auth import MSOB2CAuth
+from pyanglianwater.exceptions import UnknownEndpointError
 
 
 @pytest.fixture
@@ -83,6 +84,44 @@ async def test_get_usages(anglian_water):  # pylint: disable=redefined-outer-nam
     result = await anglian_water.get_usages(account_number=account_number, update_cache=False)
     assert "12345" in anglian_water.meters
     assert isinstance(result, (dict, list))
+
+
+@pytest.mark.asyncio
+async def test_get_usages_costs_server_error(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that get_usages still returns usage data when the costs endpoint returns a 5xx.
+
+    The costs endpoint 500s whenever the requested window has no cost data yet
+    (Anglian Water publish cost data ~3 days behind), so a server error must not
+    prevent meter readings from being parsed.
+    """
+    account_number = "12345"
+    usage_response = {
+        "result": {
+            "records": [
+                {
+                    "meters": [
+                        {
+                            "meter_serial_number": "12345",
+                            "read": 100.0,
+                            "consumption": 10.0,
+                            "read_at": "2023-10-01T00:00:00Z",
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=[
+            usage_response,
+            UnknownEndpointError(500, '{"result":{"errors":[]}}'),
+        ]
+    )
+    result = await anglian_water.get_usages(account_number=account_number)
+    assert "12345" in anglian_water.meters
+    assert isinstance(result, (dict, list))
+    assert anglian_water.meters["12345"].yesterday_water_cost == 0.0
+    assert anglian_water.meters["12345"].yesterday_sewerage_cost == 0.0
 
 
 @pytest.mark.asyncio
@@ -326,6 +365,21 @@ async def test_get_billing_summary_no_arrangement(anglian_water):  # pylint: dis
     assert isinstance(result, BillingSummary)
     assert result.payment_arrangement is None
     assert result.account_balance == 0.00
+
+
+@pytest.mark.asyncio
+async def test_get_billing_summary_server_error(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that get_billing_summary treats a 5xx as unavailable instead of raising.
+
+    Mirrors the usage-costs behaviour: the backend can 500 when summary data
+    is not available, which must not fail the wider update cycle.
+    """
+    anglian_water.api.send_request = AsyncMock(
+        side_effect=UnknownEndpointError(500, '{"result":{"errors":[]}}')
+    )
+    result = await anglian_water.get_billing_summary(account_number="12345")
+    assert result is None
+    assert anglian_water.billing is None
 
 
 def test_to_dict_includes_billing(anglian_water):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
Builds on #73 (its commit is included here; this diff shrinks to the cost changes once #73 merges).

## Problem

Even with #73's crash fix, cost data can never actually appear: `get_usages` requests costs for **calendar yesterday**, but Anglian Water publish cost data ~3 days behind, so that window never has data and `yesterday_water_cost` / `yesterday_sewerage_cost` are permanently `0.0`. Downstream, the Home Assistant integration's cost sensors always show £0.00.

## Change

Fetch costs for each day actually covered by the returned readings (those days demonstrably have cost data — verified live: 13/13 days returned costs) instead of calendar yesterday:

- `SmartMeter.daily_costs` — ISO date → `{total_cost, water_cost, sewerage_cost}`
- `SmartMeter.latest_cost_date` — most recent day with cost data
- `SmartMeter.get_hourly_costs()` — per-reading costs, distributing each day's total across its readings proportional to consumption. Tariffs are volumetric, so this gives downstream consumers (e.g. HA's `async_add_external_statistics`) hour-level cost data aligned with the usage readings.
- `yesterday_water_cost` / `yesterday_sewerage_cost` become properties returning the most recent available day's costs — existing consumers keep working and start receiving real values.

Cost days are cached across update cycles: the first update fetches one costs request per day in the readings window (~13), steady-state adds one per new day. Unpublished days are skipped with a debug log.

## Verified live

Against a real account: all 13 days of the readings window returned cost data, `yesterday_water_cost` returned the latest day's real value (£5.02), and hourly costs summed exactly to the daily totals (£110.25).

The cost window convention follows the API's 23:00→23:00 day grouping (same convention the previous code used).