### PR TITLE
Ensure cost data is only supported for specific tariffs

### DIFF
--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -7,6 +7,7 @@ from datetime import timedelta, datetime as dt
 
 from .api import API
 from .auth import MSOB2CAuth
+from .const import AW_COST_SUPPORTED_TARIFFS
 from .enum import UsagesReadGranularity
 from .exceptions import SmartMeterUnavailableError, UnknownEndpointError
 from .billing import BillingSummary
@@ -30,6 +31,7 @@ class AnglianWater:
         self.comparison: UsageComparison | None = None
         self.billing: BillingSummary | None = None
         self.updated_data_callbacks: list[Callable] = []
+        self.data_delay: int = 1 # number of days to 'delay' the data
         self._first_update = True
 
     @property
@@ -51,7 +53,10 @@ class AnglianWater:
         for meter in meter_reads:
             serial_number = meter["meter_serial_number"]
             if serial_number not in self.meters:
-                self.meters[serial_number] = SmartMeter(serial_number=serial_number)
+                self.meters[serial_number] = SmartMeter(
+                    serial_number=serial_number,
+                    cost_supported=self.current_tariff in AW_COST_SUPPORTED_TARIFFS
+                )
             if update_cache:
                 self.meters[serial_number].update_reading_cache(_response, _costs)
         return _response
@@ -63,30 +68,38 @@ class AnglianWater:
         update_cache: bool = True,
     ) -> dict:
         """Calculates the usage using the provided date range."""
-        start = dt.today().replace(hour=23, minute=0, second=0) - timedelta(days=1)
+        start = dt.today().replace(hour=23, minute=0, second=0) - timedelta(days=self.data_delay)
         _response = await self.api.send_request(
             endpoint="get_usage_details",
             body=None,
             account_number=account_number,
             GRANULARITY=str(interval),
         )
+        _costs = {}
         try:
-            _costs = await self.api.send_request(
-                endpoint="get_usage_costs",
-                body=None,
-                account_number=account_number,
-                GRANULARITY=str(interval),
-                START=start.isoformat(),
-                END=(start + timedelta(days=1)).isoformat(),
-            )
+            if self.current_tariff == "Standard":
+                _costs = await self.api.send_request(
+                    endpoint="get_usage_costs",
+                    body=None,
+                    account_number=account_number,
+                    GRANULARITY=str(interval),
+                    START=start.isoformat(),
+                    END=(start + timedelta(days=1)).isoformat(),
+                )
+            else:
+                _LOGGER.info(
+                    "Usage costs not available for account %s with tariff %s",
+                    account_number,
+                    self.current_tariff
+                )
         except UnknownEndpointError as exc:
-            if exc.status >= 500:
+            if exc.status >= 501:
                 raise
 
-            _costs = {}
             _LOGGER.exception(
-                "Usage costs not available for account %s - %s (%s)",
+                "Usage costs not available for account %s (%s) - %s (%s)",
                 account_number,
+                self.current_tariff,
                 start,
                 exc.response,
             )
@@ -110,9 +123,15 @@ class AnglianWater:
                 endpoint="get_account_summary",
                 body=None,
                 account_number=account_number,
-                HAS_PAYMENT_ARRANGEMENT=str(self.account_config.get("has_payment_arrangement", False)).lower(),
-                HAS_FUTURE_MOVE_IN=str(self.account_config.get("has_future_move_in", False)).lower(),
-                HAS_COURT_ACCOUNT=str(self.account_config.get("has_court_account", False)).lower(),
+                HAS_PAYMENT_ARRANGEMENT=str(
+                    self.account_config.get("has_payment_arrangement", False)
+                ).lower(),
+                HAS_FUTURE_MOVE_IN=str(
+                    self.account_config.get("has_future_move_in", False)
+                ).lower(),
+                HAS_COURT_ACCOUNT=str(
+                    self.account_config.get("has_court_account", False)
+                ).lower(),
             )
         except UnknownEndpointError as exc:
             if exc.status >= 500:

--- a/pyanglianwater/const.py
+++ b/pyanglianwater/const.py
@@ -98,3 +98,8 @@ AW_ENCRYPTION_IV_SIZE = 16  # 128 bits
 AW_ENCRYPTION_KEY_SIZE = 32  # 256 bits
 AW_ENCRYPTION_ITERATIONS = 100
 AW_ENCRYPTION_PBKDF2_HASH = "sha1"
+
+
+# I only know about the Standard tariff at the moment that supports cost data.
+# Add more tariffs as they are discovered.
+AW_COST_SUPPORTED_TARIFFS = ["Standard"]

--- a/pyanglianwater/meter.py
+++ b/pyanglianwater/meter.py
@@ -52,8 +52,9 @@ class SmartMeter:
     yesterday_water_cost: float = 0.0
     yesterday_sewerage_cost: float = 0.0
 
-    def __init__(self, serial_number):
+    def __init__(self, serial_number: str, cost_supported: bool = False):
         self.serial_number = serial_number
+        self.cost_supported: bool = cost_supported
         self.readings = []
 
     def update_reading_cache(self, reads: list, costs: dict):


### PR DESCRIPTION
Not all users follow the same tariff, some users are on a watersure tariff which does not support cost data (single flat fee for the whole year rather than usage based).

The tariffs that do not support costs are unable to complete the update cycle. Therefore, we'll only enable this on the standard tariff for now (while exposing info in the logs for us to capture in the future).

Additionally, if there are issues with Anglian Water's data ingestion pipeline, the backend service can report a 500 status code on the usages endpoint as discovered by @andrew-codechimp, therefore, the module will now only raise 501+ status codes when retrieving the usages data for supported tariffs.

It will be up to the upsteam implementation to use the data_delay attribute, as the ingestion pipeline is completely outside of our control (including all hardware/software components between the meter and the API), the data_delay attribute will need to be manually set by the implementor. For Home Assistant this can be a reconfiguration parameter - some properties will correctly be delayed by 24 hr, while others could be delayed by 72+ hrs.

While the "fix" is not really a fix as such for the underlying issues (Anglian Water needs to ensure their backend API endpoints are returning correct status codes as defined by RFC2616) - it should hopefully workaround the problems and address problems people have when connecting.

- Introduced AW_COST_SUPPORTED_TARIFFS constant to define tariffs that support cost data.
- Updated SmartMeter initialization to accept a cost_supported parameter.
- Modified usage calculation to conditionally fetch usage costs based on the current tariff.
- Added data_delay attribute to control the delay in data retrieval.

Related issues:
https://github.com/home-assistant/core/issues/165265
https://github.com/home-assistant/core/issues/176037