### PR TITLE
Enhance AnglianWater and SmartMeter classes to support data delay management

### DIFF
--- a/pyanglianwater/__init__.py
+++ b/pyanglianwater/__init__.py
@@ -12,7 +12,7 @@ from .enum import UsagesReadGranularity
 from .exceptions import SmartMeterUnavailableError, UnknownEndpointError
 from .billing import BillingSummary
 from .meter import SmartMeter, UsageComparison
-from .utils import is_awaitable
+from .utils import is_awaitable, parse_iso_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,8 +31,20 @@ class AnglianWater:
         self.comparison: UsageComparison | None = None
         self.billing: BillingSummary | None = None
         self.updated_data_callbacks: list[Callable] = []
-        self.data_delay: int = 1 # number of days to 'delay' the data
+        self._data_delay: int = 1  # number of days to 'delay' the data
+        self._data_delay_manual: bool = False
         self._first_update = True
+
+    @property
+    def data_delay(self) -> int:
+        """Number of days to delay data (e.g. for cost window start)."""
+        return self._data_delay
+
+    @data_delay.setter
+    def data_delay(self, value: int) -> None:
+        """Manually set data delay; locks out auto-derivation from usage metadata."""
+        self._data_delay = value
+        self._data_delay_manual = True
 
     @property
     def current_tariff(self) -> str:
@@ -42,10 +54,21 @@ class AnglianWater:
 
     async def parse_usages(self, _response, _costs, update_cache: bool = True) -> dict:
         """Parse given usage details."""
-        if "result" in _response:
-            _response = _response["result"]
-        if "records" in _response:
-            _response = _response["records"]
+        first_meter_read_date = None
+        last_meter_read_date = None
+        if isinstance(_response, dict):
+            result = _response["result"] if "result" in _response else _response
+            if isinstance(result, dict):
+                first_raw = result.get("first_meter_read_date")
+                last_raw = result.get("last_meter_read_date")
+                if first_raw:
+                    first_meter_read_date = parse_iso_datetime(first_raw)
+                if last_raw:
+                    last_meter_read_date = parse_iso_datetime(last_raw)
+                    if last_meter_read_date is not None and not self._data_delay_manual:
+                        lag = (dt.today().date() - last_meter_read_date.date()).days
+                        self._data_delay = max(lag, 0)
+                _response = result["records"] if "records" in result else result
         if len(_response) == 0:
             return {}
         # Get meter serial numbers from the nested meters dict
@@ -57,6 +80,8 @@ class AnglianWater:
                     serial_number=serial_number,
                     cost_supported=self.current_tariff in AW_COST_SUPPORTED_TARIFFS
                 )
+            self.meters[serial_number].first_meter_read_date = first_meter_read_date
+            self.meters[serial_number].last_meter_read_date = last_meter_read_date
             if update_cache:
                 self.meters[serial_number].update_reading_cache(_response, _costs)
         return _response
@@ -68,12 +93,16 @@ class AnglianWater:
         update_cache: bool = True,
     ) -> dict:
         """Calculates the usage using the provided date range."""
-        start = dt.today().replace(hour=23, minute=0, second=0) - timedelta(days=self.data_delay)
         _response = await self.api.send_request(
             endpoint="get_usage_details",
             body=None,
             account_number=account_number,
             GRANULARITY=str(interval),
+        )
+        # Parse usage first so data_delay can be auto-derived before cost fetch.
+        records = await self.parse_usages(_response, {}, update_cache=False)
+        start = dt.today().replace(hour=23, minute=0, second=0) - timedelta(
+            days=self.data_delay
         )
         _costs = {}
         try:
@@ -103,7 +132,11 @@ class AnglianWater:
                 start,
                 exc.response,
             )
-        return await self.parse_usages(_response, _costs, update_cache)
+        if update_cache and records:
+            for meter_data in records[0]["meters"]:
+                serial_number = meter_data["meter_serial_number"]
+                self.meters[serial_number].update_reading_cache(records, _costs)
+        return records
 
     async def get_comparison(self, account_number: str) -> UsageComparison:
         """Get usage comparison data."""

--- a/pyanglianwater/const.py
+++ b/pyanglianwater/const.py
@@ -103,3 +103,6 @@ AW_ENCRYPTION_PBKDF2_HASH = "sha1"
 # I only know about the Standard tariff at the moment that supports cost data.
 # Add more tariffs as they are discovered.
 AW_COST_SUPPORTED_TARIFFS = ["Standard"]
+
+# Normal smart-meter lag is ~1 day; some areas lag by up to 4 days.
+AW_METER_MAX_LAG_DAYS = 4

--- a/pyanglianwater/meter.py
+++ b/pyanglianwater/meter.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 
+from .const import AW_METER_MAX_LAG_DAYS
 from .utils import parse_iso_datetime
 
 
@@ -56,6 +57,8 @@ class SmartMeter:
         self.serial_number = serial_number
         self.cost_supported: bool = cost_supported
         self.readings = []
+        self.first_meter_read_date: datetime | None = None
+        self.last_meter_read_date: datetime | None = None
 
     def update_reading_cache(self, reads: list, costs: dict):
         """Updates the cache of meter reads for the smart meter."""
@@ -67,6 +70,14 @@ class SmartMeter:
                     self.last_reading = float(meter["read"])
         self.yesterday_water_cost = costs.get("result", {}).get("water_cost", 0.0)
         self.yesterday_sewerage_cost = costs.get("result", {}).get("sewerage_cost", 0.0)
+
+    @property
+    def available(self) -> bool:
+        """Return True when last meter read is within the expected lag window."""
+        if self.last_meter_read_date is None:
+            return False
+        lag = (datetime.now().date() - self.last_meter_read_date.date()).days
+        return lag <= AW_METER_MAX_LAG_DAYS
 
     @property
     def get_yesterday_readings(self) -> list:
@@ -116,6 +127,17 @@ class SmartMeter:
             "last_reading": self.last_reading,
             "readings": self.readings,
             "consumption": self.latest_consumption,
+            "available": self.available,
+            "first_meter_read_date": (
+                self.first_meter_read_date.isoformat()
+                if self.first_meter_read_date
+                else None
+            ),
+            "last_meter_read_date": (
+                self.last_meter_read_date.isoformat()
+                if self.last_meter_read_date
+                else None
+            ),
         }
 
     def __iter__(self):

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,5 +1,6 @@
 """Tests for the AnglianWater module."""
 
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -31,6 +32,8 @@ def test_initialization(anglian_water):  # pylint: disable=redefined-outer-name
     assert anglian_water.meters == {}
     assert anglian_water.account_config == {}
     assert anglian_water.updated_data_callbacks == []
+    assert anglian_water.data_delay == 1
+    assert anglian_water._data_delay_manual is False  # pylint: disable=protected-access
     assert isinstance(anglian_water.api, API)
 
 
@@ -53,6 +56,71 @@ async def test_parse_usages(anglian_water):  # pylint: disable=redefined-outer-n
     await anglian_water.parse_usages(mock_response, mock_costs, update_cache=False)
     assert "12345" in anglian_water.meters
     assert isinstance(anglian_water.meters["12345"], SmartMeter)
+
+
+@pytest.mark.asyncio
+async def test_parse_usages_auto_data_delay(anglian_water):  # pylint: disable=redefined-outer-name
+    """Test that parse_usages derives data_delay from last_meter_read_date."""
+    last_read = (datetime.now() - timedelta(days=2)).replace(
+        hour=23, minute=0, second=0, microsecond=0
+    )
+    mock_response = {
+        "result": {
+            "first_meter_read_date": (datetime.now() - timedelta(days=30)).isoformat(
+                timespec="seconds"
+            ),
+            "last_meter_read_date": last_read.isoformat(timespec="seconds"),
+            "meter_count": 1,
+            "records": [
+                {
+                    "meters": [
+                        {
+                            "meter_serial_number": "12345",
+                            "read": 100.0,
+                            "consumption": 10.0,
+                            "read_at": last_read.isoformat(timespec="seconds"),
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+    await anglian_water.parse_usages(mock_response, {}, update_cache=False)
+    assert anglian_water.data_delay == 2
+    assert anglian_water.meters["12345"].last_meter_read_date is not None
+    assert anglian_water.meters["12345"].available is True
+
+
+@pytest.mark.asyncio
+async def test_parse_usages_manual_data_delay_not_overwritten(
+    anglian_water,
+):  # pylint: disable=redefined-outer-name
+    """Test that a manual data_delay override is preserved on subsequent parse."""
+    anglian_water.data_delay = 3
+    assert anglian_water._data_delay_manual is True  # pylint: disable=protected-access
+
+    last_read = (datetime.now() - timedelta(days=1)).replace(
+        hour=23, minute=0, second=0, microsecond=0
+    )
+    mock_response = {
+        "result": {
+            "last_meter_read_date": last_read.isoformat(timespec="seconds"),
+            "records": [
+                {
+                    "meters": [
+                        {
+                            "meter_serial_number": "12345",
+                            "read": 100.0,
+                            "consumption": 10.0,
+                            "read_at": last_read.isoformat(timespec="seconds"),
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+    await anglian_water.parse_usages(mock_response, {}, update_cache=False)
+    assert anglian_water.data_delay == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -83,8 +83,28 @@ def test_latest_read(smart_meter, sample_readings):  # pylint: disable=redefined
 def test_to_dict(smart_meter, sample_readings):  # pylint: disable=redefined-outer-name
     """Test that to_dict returns a dictionary with all meter data."""
     smart_meter.update_reading_cache(sample_readings, {})
+    smart_meter.last_meter_read_date = datetime.now() - timedelta(days=1)
     meter_dict = smart_meter.to_dict()
     assert meter_dict["serial_number"] == "12345"
     assert meter_dict["last_reading"] == 100.0
     assert meter_dict["consumption"] == 10.0
     assert len(meter_dict["readings"]) == 1
+    assert meter_dict["available"] is True
+    assert meter_dict["last_meter_read_date"] is not None
+
+
+def test_available_missing_last_read(smart_meter):  # pylint: disable=redefined-outer-name
+    """Test that available is False when last_meter_read_date is unset."""
+    assert smart_meter.available is False
+
+
+def test_available_within_max_lag(smart_meter):  # pylint: disable=redefined-outer-name
+    """Test that available is True when last read is within the max lag window."""
+    smart_meter.last_meter_read_date = datetime.now() - timedelta(days=4)
+    assert smart_meter.available is True
+
+
+def test_available_stale(smart_meter):  # pylint: disable=redefined-outer-name
+    """Test that available is False when last read is older than the max lag."""
+    smart_meter.last_meter_read_date = datetime.now() - timedelta(days=5)
+    assert smart_meter.available is False


### PR DESCRIPTION
- Added properties for data delay in AnglianWater, allowing manual overrides and auto-derivation from meter read dates.
- Updated parse_usages method to derive data delay based on last meter read date.
- Introduced first_meter_read_date and last_meter_read_date attributes in SmartMeter to track meter reading dates.
- Implemented availability check in SmartMeter based on last meter read date and maximum lag days.

Includes tests for new functionality and ensures backward compatibility.